### PR TITLE
fix: 修正 B 帧时序（剥离所有 type-25 NAL + 改用 MP4Box 封装）

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 
 我不是专业 JS 开发，所以没做那么细致。
 
+## 依赖
+
+- [Node.js](https://nodejs.org/)
+- [FFmpeg](https://ffmpeg.org/)（解封装/拼接音视频）
+- [MP4Box](https://github.com/gpac/gpac)（GPAC 自带，最终封装用，详见下文「时序」一节）
+
 ## 使用方法
 
 我用的是 Linux 系统，所以我只能说 Linux 下怎么用。Windows 下需要你自己想办法了
@@ -41,6 +47,14 @@ main.js 后可以跟 `--quiet-ffmpeg` 不显示 ffmpeg 的输出，然后跟的�
 注意！切片会按照你给定的顺序进行拼接，所以要注意不要弄串了。
 
 最后一个参数就是输出文件。
+
+### 关于时序（B 帧重排）
+
+最终封装改用了 **MP4Box** 而不是 ffmpeg。原因：解密产物是裸 H.264（Annex-B）流，
+ffmpeg 的裸流解复用器不会从 POC 重建合成时间（composition time），会把每一帧都写成
+`pts == dts`。这样在按解码器重排的播放器（mpv/VLC）里看似正常，但在信任容器时间戳的
+播放器/软件（QuickTime、浏览器、各类剪辑软件）里，B 帧会按解码顺序显示，画面来回抽搐。
+MP4Box 会从 POC 重建 `ctts` 表，输出在所有播放器里都正确，且全程无损（不重编码）。
 
 ## Misc.
 

--- a/main.js
+++ b/main.js
@@ -279,14 +279,18 @@ async function mainDecrypter(CNTVH5PlayerModule) {
                 return;
             }
 
-            while (currentNALIndex < nalus.length && nalus[currentNALIndex].nalUnitType === 25)
-                currentNALIndex++;
-
-            while (currentNALIndex < nalus.length)
+            // type-25 NAL units are CCTV's decryption markers; strip ALL of
+            // them (not just a leading run) so the output is clean H.264.
+            while (currentNALIndex < nalus.length) {
+                if (nalus[currentNALIndex].nalUnitType === 25) {
+                    currentNALIndex++;
+                    continue;
+                }
                 if (!outFile.write(nalus[currentNALIndex++].dump())) {
                     outFile.once("drain", writeNALUs)
                     break;
                 }
+            }
 
             if (currentNALIndex >= nalus.length)
                 outFile.end();
@@ -317,12 +321,27 @@ async function mainDecrypter(CNTVH5PlayerModule) {
         { flag: 'a' }
     );
 
-    await runFFmpeg(
-        [ concatVideoListFileName, concatAudioListFileName ],
-        process.argv.at(-1),
-        [],
-        "-map 0 -map 1".split(' ')
+    // First concatenate the per-segment elementary streams.
+    const concatVideoFile = path.join(tmpdir, "video.264"),
+          concatAudioFile = path.join(tmpdir, "audio.m4a");
+    await runFFmpeg([ concatVideoListFileName ], concatVideoFile, [], "-map 0".split(' '));
+    await runFFmpeg([ concatAudioListFileName ], concatAudioFile, [], "-map 0".split(' '));
+
+    // Mux with MP4Box, not ffmpeg: ffmpeg's raw-H.264 demuxer does not
+    // reconstruct composition order from POC, so it writes every frame with
+    // pts==dts. Players that trust container timestamps (QuickTime, browsers,
+    // NLEs) then show B-frames in decode order -> visible back-and-forth
+    // judder. MP4Box rebuilds the composition-time table (ctts) from POC.
+    const mp4boxProcess = child_process.spawn(
+        "MP4Box",
+        [ "-add", concatVideoFile, "-add", concatAudioFile, "-new", process.argv.at(-1) ],
+        { stdio: "inherit" }
     );
+    const [mp4boxCode] = await events.once(mp4boxProcess, "exit");
+    if (mp4boxCode) {
+        console.error("Error occurred while running MP4Box.");
+        process.exit(1);
+    }
     await fsPromises.rm(tmpdir, { force: true, recursive: true });
     console.log("finished.");
 }


### PR DESCRIPTION
## 问题

解密出来的 mp4 在**信任容器时间戳的播放器/软件**（QuickTime、Finder 预览、浏览器、各类剪辑软件）里画面会**来回抽搐**；在 mpv/VLC 里因为解码器自己按 POC 重排所以看不出来。这和 #2（音画同步）不是一回事。

## 根因

两层叠加：

1. **type-25 NAL 泄漏**。`writeNALUs` 本意是剥掉 CCTV 的解密标记 NAL（type 25），但只在每次进入函数时跳过了**开头连续的**那串，内层 `while` 把后续每个 inter 帧前的 type-25 都写进了输出流。

   ```
   ref（正常源）:  9 7 8 6 6 6 [5] 9 6 [1] 9 6 [1] ...
   旧版输出     :  9 7 8 6 6 6 [25] 5 9 6 [25] 1 9 6 [25] 1 ...   ← 每个切片前都残留 25
   ```

2. **裸流封装不重排 B 帧**。解密产物是裸 H.264（Annex-B），ffmpeg 的裸流解复用器**不会从 POC 重建合成时间**，把每帧都写成 `pts == dts`（实测连干净的正常源经 `ffmpeg -i x.264 -c copy` 也是 `has_b_frames=0`）。于是 B 帧按解码顺序显示 → 抽搐。残留的 type-25 还会让 MP4Box 也无法正确解析（帧率被识别成 1.2M、不重排）。

## 修复

- `writeNALUs`：剥离**所有** type-25，而非仅开头一串。
- 最终封装由 ffmpeg 改为 **MP4Box**：它会从 POC 重建 `ctts` 表。剥掉 type-25 后 MP4Box 无需 `-fps` 即可自动识别帧率并正确重排。**全程无损，不重编码。**

## 验证（前 8 帧 packet pts/dts）

```
修复前: pts==dts （0.000,0.000  0.040,0.040 ...）           → 不重排
修复后: pts!=dts （0.000,-0.040  0.080,0.000  0.040,0.040） → 正确重排
        has_b_frames=1, avg_frame_rate=25/1, 输出流已无 type-25
```

在多个真实视频（CCTV-10 720p、CCTV-4K 1080p；2019 / 2023 / 2025 的节目）上端到端验证通过。

## 注意

本 PR 给最终封装引入了 **MP4Box（GPAC）** 依赖，已在 README 的「依赖」与「关于时序」两节说明。这是目前能**无损**重建 B 帧合成顺序的最简方案（ffmpeg 裸流封装做不到；重编码则有损）。如果你更希望保持 ffmpeg-only，也欢迎讨论其他思路（例如在管线里保留原始 .ts 的时间戳）。
